### PR TITLE
fix: remove duplicate content on landing page

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -15,7 +15,6 @@ function App() {
   return (
     <div className="App">
       <ScrollIndicator />
-      <Home />
       <PreloaderContainer>
         <Home />
       </PreloaderContainer>


### PR DESCRIPTION
Removed Home component outside PreloaderContainer in App.js  as it is already passed as a child

https://github.com/user-attachments/assets/f3c698db-9590-417b-ae47-bae18c9cdad1

